### PR TITLE
use identify and trackIdentify methods for fewer requests, better attribution

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@ actions-shared/ @segmentio/build-experience-team
 ajv-human-errors/ @segmentio/build-experience-team
 
 # Browser destinations
-browser-destinations/ @segmentio/libraries-web-team @segmentio/strategic-connections-team
+browser-destinations/ @segmentio/libraries-web-team @segmentio/strategic-connections-team @segmentio/build-experience-team
 
 # CLI private libs
 cli-internal/ @segmentio/build-experience-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@ actions-shared/ @segmentio/build-experience-team
 ajv-human-errors/ @segmentio/build-experience-team
 
 # Browser destinations
-browser-destinations/ @segmentio/libraries-web-team 
+browser-destinations/ @segmentio/libraries-web-team @segmentio/strategic-connections-team
 
 # CLI private libs
 cli-internal/ @segmentio/build-experience-team
@@ -21,7 +21,7 @@ cli/ @segmentio/build-experience-team
 core/ @segmentio/build-experience-team
 
 # Destination definitions and their actions
-destination-actions/ @segmentio/build-experience-team
+destination-actions/ @segmentio/build-experience-team @segmentio/strategic-connections-team
 
 # Utilities for event payload validation against an action's subscription AST.
 destination-subscriptions/ @segmentio/build-experience-team

--- a/.husky/gitleaks-rules.toml
+++ b/.husky/gitleaks-rules.toml
@@ -16,14 +16,6 @@ description = "Facebook System User Access Token"
 regex = '''EAA[0-9A-Za-z]{100,}'''
 tags = ["token", "Facebook Token"]
 
-[[rules]]
-description = "Tik-Tok accessToken"
-regex = '''[0-9A-Za-z]{40}'''
-tags = ["token", "Tik-Tok"]
-[[rules.entropies]]
-Max = "4.5"
-Min = "3.5"
-
 # Default gitleaks rules (from https://raw.githubusercontent.com/zricethezav/gitleaks/master/config/gitleaks.toml)
 
 # Gitleaks rules are defined by regular expressions and entropy ranges.

--- a/packages/browser-destinations/README.md
+++ b/packages/browser-destinations/README.md
@@ -16,6 +16,14 @@ This package contains the implementations for browser destinations.
 
 See the [Actions CLI](https://github.com/segmentio/action-destinations#actions-cli) of the root directory of this repo to learn how to interact with the Actions CLI. Interacting with the actions CLI will allow you to create new destinations, actions and update your type definitions.
 
+### Types
+
+When udating the types inside of your actions remember to regenerate the types of your integration by running this command in the top level directory.
+
+```
+bin/run generate:types
+```
+
 ### Manual testing
 
 You can run a test webpage that makes every browser destination available for testing.

--- a/packages/browser-destinations/README.md
+++ b/packages/browser-destinations/README.md
@@ -18,7 +18,7 @@ See the [Actions CLI](https://github.com/segmentio/action-destinations#actions-c
 
 ### Types
 
-When udating the types inside of your actions remember to regenerate the types of your integration by running this command in the top level directory.
+When updating the types inside of your actions remember to regenerate the types of your integration by running this command in the top level directory.
 
 ```
 bin/run generate:types

--- a/packages/browser-destinations/src/destinations/adobe-target/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/__tests__/index.test.ts
@@ -17,7 +17,7 @@ describe('Adobe Target Web', () => {
       client_code: 'segmentexchangepartn',
       admin_number: '10',
       version: '2.8.0',
-      cookie_domain: 'localhost',
+      cookie_domain: 'segment.com',
       mbox_name: 'target-global-mbox',
       subscriptions
     })

--- a/packages/browser-destinations/src/destinations/adobe-target/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/index.ts
@@ -9,10 +9,12 @@ import upsertProfile from './upsertProfile'
 declare global {
   interface Window {
     adobe: Adobe
+    targetPageParams: Function
+    pageParams: Object
   }
 }
 
-export const destination: BrowserDestinationDefinition<Settings, unknown> = {
+export const destination: BrowserDestinationDefinition<Settings, Adobe> = {
   name: 'Adobe Target Web',
   slug: 'actions-adobe-target-web',
   mode: 'device',

--- a/packages/browser-destinations/src/destinations/adobe-target/init-script.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/init-script.ts
@@ -1,9 +1,18 @@
 /* eslint-disable */
 // @ts-nocheck
 
+import { getPageParams } from './utils'
+
 export function initScript(settings) {
+  window.pageParams = {}
   window.targetGlobalSettings = {
     cookieDomain: settings.cookie_domain,
     enabled: true
+  }
+
+  // DO NOT RENAME. This function is required by Adobe Target.
+  // Learn More: https://experienceleague.adobe.com/docs/target/using/implement-target/client-side/at-js-implementation/functions-overview/targetpageparams.html?lang=en
+  window.targetPageParams = function () {
+    return getPageParams()
   }
 }

--- a/packages/browser-destinations/src/destinations/adobe-target/types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/types.ts
@@ -1,1 +1,7 @@
-export type Adobe = unknown
+export type Adobe = {
+  target: Target
+}
+
+type Target = {
+  trackEvent: Function
+}

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/__tests__/index.test.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/__tests__/index.test.ts
@@ -2,45 +2,130 @@ import { Analytics, Context } from '@segment/analytics-next'
 import adobeTarget, { destination } from '../../index'
 import { Subscription } from '../../../../lib/browser-destinations'
 
-// TODO: Fill this test since it's a copy of the main test.
-
 describe('Adobe Target Web', () => {
-  test('calls identify', async () => {
-    const subscriptions: Subscription[] = [
-      {
-        partnerAction: 'upsertProfile',
-        name: 'Upsert Profile',
-        enabled: true,
-        subscribe: 'type = "identify"',
-        mapping: {}
-      }
-    ]
-    const [event] = await adobeTarget({
-      client_code: 'segmentexchangepartn',
-      admin_number: '10',
-      version: '2.8.0',
-      cookie_domain: 'localhost',
-      mbox_name: 'target-global-mbox',
-      subscriptions
-    })
-
-    jest.spyOn(destination, 'initialize')
-
-    await event.load(Context.system(), {} as Analytics)
-    expect(destination.initialize).toHaveBeenCalled()
-
-    const scripts = window.document.querySelectorAll('script')
-    expect(scripts).toMatchInlineSnapshot(`
-      NodeList [
-        <script
-          src="https://admin10.testandtarget.omniture.com/admin/rest/v1/libraries/atjs/download?client=segmentexchangepartn&version=2.8.0"
-          status="loaded"
-          type="text/javascript"
-        />,
-        <script>
-          // the emptiness
-        </script>,
+  describe('#identify', () => {
+    test('calls identify and simulates a login flow', async () => {
+      const subscriptions: Subscription[] = [
+        {
+          partnerAction: 'upsertProfile',
+          name: 'Upsert Profile',
+          enabled: true,
+          subscribe: 'type = "identify"',
+          mapping: {
+            anonymousId: {
+              '@path': '$.anonymousId'
+            },
+            userId: {
+              '@path': '$.userId'
+            },
+            traits: {
+              '@path': '$.traits'
+            }
+          }
+        }
       ]
-    `)
+
+      const targetSettings = {
+        client_code: 'segmentexchangepartn',
+        admin_number: '10',
+        version: '2.8.0',
+        cookie_domain: 'segment.com',
+        mbox_name: 'target-global-mbox'
+      }
+
+      const identifyParams = {
+        traits: {
+          favorite_color: 'blue',
+          location: {
+            country_code: 'MX',
+            state: 'Mich'
+          }
+        }
+      }
+
+      const [event] = await adobeTarget({
+        ...targetSettings,
+        subscriptions
+      })
+
+      jest.spyOn(destination, 'initialize')
+
+      destination.actions.upsertProfile.perform = jest.fn(destination.actions.upsertProfile.perform)
+
+      await event.load(Context.system(), {} as Analytics)
+      expect(destination.initialize).toHaveBeenCalled()
+
+      await event.identify?.(
+        new Context({
+          anonymousId: 'random-id-42',
+          type: 'identify',
+          ...identifyParams
+        })
+      )
+
+      expect(destination.actions.upsertProfile.perform).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          payload: {
+            anonymousId: 'random-id-42',
+            traits: {
+              favorite_color: 'blue',
+              location: {
+                country_code: 'MX',
+                state: 'Mich'
+              }
+            }
+          }
+        })
+      )
+
+      expect(window.pageParams).toEqual({
+        profile: {
+          mbox3rdpartyid: 'random-id-42',
+          favorite_color: 'blue',
+          location: {
+            country_code: 'MX',
+            state: 'Mich'
+          }
+        }
+      })
+
+      await event.identify?.(
+        new Context({
+          userId: 'The-Real-ID',
+          anonymousId: 'random-id-42',
+          type: 'identify',
+          ...identifyParams
+        })
+      )
+
+      expect(destination.actions.upsertProfile.perform).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          payload: {
+            userId: 'The-Real-ID',
+            anonymousId: 'random-id-42',
+            traits: {
+              favorite_color: 'blue',
+              location: {
+                country_code: 'MX',
+                state: 'Mich'
+              }
+            }
+          }
+        })
+      )
+
+      expect(window.pageParams).toEqual({
+        profile: {
+          mbox3rdpartyid: 'The-Real-ID',
+          favorite_color: 'blue',
+          location: {
+            country_code: 'MX',
+            state: 'Mich'
+          }
+        }
+      })
+    })
   })
 })

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/generated-types.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/generated-types.ts
@@ -2,9 +2,17 @@
 
 export interface Payload {
   /**
-   * Hash of properties for this profile.
+   * A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.
    */
-  profile?: {
+  userId?: string
+  /**
+   * Anonymous identifier for the user
+   */
+  anonymousId: string
+  /**
+   * Profile parameters specific to a user.
+   */
+  traits: {
     [k: string]: unknown
   }
 }

--- a/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/upsertProfile/index.ts
@@ -2,6 +2,7 @@ import type { BrowserActionDefinition } from '../../../lib/browser-destinations'
 import type { Settings } from '../generated-types'
 import { Adobe } from '../types'
 import type { Payload } from './generated-types'
+import { setPageParams } from '../utils'
 
 const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   title: 'Upsert Profile',
@@ -9,17 +10,71 @@ const action: BrowserActionDefinition<Settings, Adobe, Payload> = {
   platform: 'web',
   defaultSubscription: 'type = "identify"',
   fields: {
-    profile: {
-      type: 'object',
-      description: 'Hash of properties for this profile.',
-      label: 'Profile Properties',
+    userId: {
+      type: 'string',
+      description:
+        'A user’s unique visitor ID. Setting an Mbox 3rd Party ID allows for updates via the Adobe Target Cloud Mode Destination. For more information, please see our Adobe Target Destination documentation.',
+      label: 'User ID',
       default: {
-        '@path': '$.profile'
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
+    },
+    anonymousId: {
+      type: 'string',
+      required: true,
+      description: 'Anonymous identifier for the user',
+      label: 'Anonymous ID',
+      default: {
+        '@path': '$.anonymousId'
+      }
+    },
+    traits: {
+      type: 'object',
+      required: true,
+      description: 'Profile parameters specific to a user.',
+      label: 'User Attributes',
+      default: {
+        '@path': '$.traits'
       }
     }
   },
-  perform: () => {
-    return
+  perform: (Adobe, event) => {
+    /*
+       NOTE:
+       identify() and track() actions leverage the same function (adobe.target.trackEvent()) to send data to Adobe.
+       identify does not pass an event name, track does.
+    */
+    const user = {
+      mbox3rdpartyid: event.payload.anonymousId
+    }
+    if (event.payload.userId) {
+      user.mbox3rdpartyid = event.payload.userId
+    }
+
+    /*
+      NOTE:
+      Profile data needs to be set before the call to adobe.target.trackEvent.
+      This is because the profile data needs to be part of the global pageParams object.
+    */
+    setPageParams({
+      profile: {
+        ...event.payload.traits,
+        ...user
+      }
+    })
+
+    const params = {
+      mbox: event.settings.mbox_name,
+      params: {
+        type: 'profile_update' // DO NOT CHANGE. profile_update is used to differentiate between track and identify calls.
+      }
+    }
+
+    Adobe.target.trackEvent(params)
   }
 }
 

--- a/packages/browser-destinations/src/destinations/adobe-target/utils.ts
+++ b/packages/browser-destinations/src/destinations/adobe-target/utils.ts
@@ -1,0 +1,10 @@
+/* eslint-disable */
+// @ts-nocheck
+
+export function getPageParams() {
+  return window.pageParams
+}
+
+export function setPageParams(params) {
+  return (window.pageParams = { ...window.pageParams, ...params })
+}

--- a/packages/browser-destinations/src/destinations/sprig-web/identifyUser/index.ts
+++ b/packages/browser-destinations/src/destinations/sprig-web/identifyUser/index.ts
@@ -39,14 +39,21 @@ const action: BrowserActionDefinition<Settings, Sprig, Payload> = {
   },
   perform: (Sprig, event) => {
     const payload = event.payload
-    if (!payload) return
+    if (!payload || typeof payload !== 'object' || !(payload.userId || payload.anonymousId || payload.traits)) return
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sprigIdentifyAndSetAttributesPayload: {
+      userId?: string
+      anonymousId?: string
+      attributes?: { [key: string]: any }
+    } = {}
 
     if (payload.userId) {
-      Sprig('setUserId', payload.userId)
+      sprigIdentifyAndSetAttributesPayload.userId = payload.userId
     }
 
     if (payload.anonymousId) {
-      Sprig('setPartnerAnonymousId', payload.anonymousId)
+      sprigIdentifyAndSetAttributesPayload.anonymousId = payload.anonymousId
     }
 
     if (payload.traits && Object.keys(payload.traits).length > 0) {
@@ -55,9 +62,10 @@ const action: BrowserActionDefinition<Settings, Sprig, Payload> = {
         traits['!email'] = traits.email
         delete traits.email
       }
-
-      Sprig('setAttributes', traits)
+      sprigIdentifyAndSetAttributesPayload.attributes = traits
     }
+
+    Sprig('identifyAndSetAttributes', sprigIdentifyAndSetAttributesPayload)
   }
 }
 

--- a/packages/browser-destinations/src/destinations/sprig-web/trackEvent/index.ts
+++ b/packages/browser-destinations/src/destinations/sprig-web/trackEvent/index.ts
@@ -39,16 +39,20 @@ const action: BrowserActionDefinition<Settings, Sprig, Payload> = {
   },
   perform: (Sprig, event) => {
     const payload = event.payload
-    if (!payload) return
+    if (!payload || typeof payload !== 'object' || !payload.name) return
 
+    const sprigIdentifyAndTrackPayload: { eventName: string; userId?: string; anonymousId?: string } = {
+      eventName: payload.name
+    }
     if (payload.userId) {
-      Sprig('setUserId', payload.userId)
+      sprigIdentifyAndTrackPayload.userId = payload.userId
     }
 
     if (payload.anonymousId) {
-      Sprig('setPartnerAnonymousId', payload.anonymousId)
+      sprigIdentifyAndTrackPayload.anonymousId = payload.anonymousId
     }
-    Sprig('track', payload.name)
+
+    Sprig('identifyAndTrack', sprigIdentifyAndTrackPayload)
   }
 }
 

--- a/packages/browser-destinations/src/destinations/sprig-web/updateUserId/index.ts
+++ b/packages/browser-destinations/src/destinations/sprig-web/updateUserId/index.ts
@@ -30,15 +30,19 @@ const action: BrowserActionDefinition<Settings, Sprig, Payload> = {
   },
   perform: (Sprig, event) => {
     const payload = event.payload
-    if (!payload) return
+    if (!payload || typeof payload !== 'object' || !(payload.userId || payload.anonymousId)) return
+
+    const sprigIdentifyAndSetAttributesPayload: { userId?: string; anonymousId?: string } = {}
 
     if (payload.userId) {
-      Sprig('setUserId', payload.userId)
+      sprigIdentifyAndSetAttributesPayload.userId = payload.userId
     }
 
     if (payload.anonymousId) {
-      Sprig('setPartnerAnonymousId', payload.anonymousId)
+      sprigIdentifyAndSetAttributesPayload.anonymousId = payload.anonymousId
     }
+
+    Sprig('identifyAndSetAttributes', sprigIdentifyAndSetAttributesPayload)
   }
 }
 

--- a/packages/destination-actions/src/destinations/amplitude/mapUser/index.ts
+++ b/packages/destination-actions/src/destinations/amplitude/mapUser/index.ts
@@ -27,7 +27,7 @@ const action: ActionDefinition<Settings, Payload> = {
     min_id_length: {
       label: 'Minimum ID Length',
       description:
-        'Amplitude has a default minimum id length of 5 characters for user_id and device_id fields. This field allows the minimum to be overridden to allow shorter id lengths.',
+        'Amplitude has a default minimum id length (`min_id_length`) of 5 characters for user_id and device_id fields. This field allows the minimum to be overridden to allow shorter id lengths.',
       allowNull: true,
       type: 'integer'
     }

--- a/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/__tests__/addPaymentInfo.test.ts
@@ -40,6 +40,9 @@ describe('GA4', () => {
           client_id: {
             '@path': '$.anonymousId'
           },
+          user_id: {
+            '@path': '$.userId'
+          },
           items: [
             {
               item_name: {
@@ -80,7 +83,7 @@ describe('GA4', () => {
       `)
 
       expect(responses[0].options.body).toMatchInlineSnapshot(
-        `"{\\"client_id\\":\\"anon-2134\\",\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}]}}]}"`
+        `"{\\"client_id\\":\\"anon-2134\\",\\"user_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}]}}]}"`
       )
     })
 
@@ -296,6 +299,89 @@ describe('GA4', () => {
       } catch (e) {
         expect(e.message).toBe('One of item-level currency or top-level currency is required.')
       }
+    })
+
+    it('should correctly append params', async () => {
+      nock('https://www.google-analytics.com/mp/collect')
+        .post(`?measurement_id=${measurementId}&api_secret=${apiSecret}`)
+        .reply(201, {})
+
+      const event = createTestEvent({
+        event: 'Payment Info Entered',
+        userId: 'abc123',
+        anonymousId: 'anon-2134',
+        type: 'track',
+        properties: {
+          products: [
+            {
+              product_id: '12345abcde',
+              name: 'Quadruple Stack Oreos, 52 ct',
+              currency: 'USD',
+              price: 12.99,
+              quantity: 1
+            }
+          ]
+        }
+      })
+
+      const responses = await testDestination.testAction('addPaymentInfo', {
+        event,
+        settings: {
+          apiSecret,
+          measurementId
+        },
+        mapping: {
+          client_id: {
+            '@path': '$.anonymousId'
+          },
+          user_id: {
+            '@path': '$.userId'
+          },
+          params: {
+            Test_key: 'test_value'
+          },
+          items: [
+            {
+              item_name: {
+                '@path': `$.properties.products.0.name`
+              },
+              item_id: {
+                '@path': `$.properties.products.0.product_id`
+              },
+              currency: {
+                '@path': `$.properties.products.0.currency`
+              },
+              price: {
+                '@path': `$.properties.products.0.price`
+              },
+              quantity: {
+                '@path': `$.properties.products.0.quantity`
+              }
+            }
+          ]
+        },
+        useDefaultMappings: false
+      })
+
+      expect(responses.length).toBe(1)
+      expect(responses[0].status).toBe(201)
+
+      expect(responses[0].request.headers).toMatchInlineSnapshot(`
+        Headers {
+          Symbol(map): Object {
+            "content-type": Array [
+              "application/json",
+            ],
+            "user-agent": Array [
+              "Segment (Actions)",
+            ],
+          },
+        }
+      `)
+
+      expect(responses[0].options.body).toMatchInlineSnapshot(
+        `"{\\"client_id\\":\\"anon-2134\\",\\"user_id\\":\\"abc123\\",\\"events\\":[{\\"name\\":\\"add_payment_info\\",\\"params\\":{\\"items\\":[{\\"item_name\\":\\"Quadruple Stack Oreos, 52 ct\\",\\"item_id\\":\\"12345abcde\\",\\"currency\\":\\"USD\\",\\"price\\":12.99,\\"quantity\\":1}],\\"Test_key\\":\\"test_value\\"}}]}"`
+      )
     })
   })
 })

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string
@@ -102,4 +106,10 @@ export interface Payload {
      */
     quantity?: number
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addPaymentInfo/index.ts
@@ -3,7 +3,16 @@ import { CURRENCY_ISO_CODES } from '../constants'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id, currency, value, coupon, payment_type, items_multi_products } from '../ga4-properties'
+import {
+  user_id,
+  client_id,
+  currency,
+  value,
+  coupon,
+  payment_type,
+  items_multi_products,
+  params
+} from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add Payment Info',
@@ -11,6 +20,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Payment Info Entered"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     currency: { ...currency },
     value: { ...value },
     coupon: { ...coupon },
@@ -18,7 +28,8 @@ const action: ActionDefinition<Settings, Payload> = {
     items: {
       ...items_multi_products,
       required: true
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.includes(payload.currency)) {
@@ -67,6 +78,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'add_payment_info',
@@ -75,7 +87,8 @@ const action: ActionDefinition<Settings, Payload> = {
               value: payload.value,
               coupon: payload.coupon,
               payment_type: payload.payment_type,
-              items: googleItems
+              items: googleItems,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string
@@ -94,4 +98,10 @@ export interface Payload {
    * The monetary value of the event.
    */
   value?: number
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToCart/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { ProductItem } from '../ga4-types'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { value, currency, client_id, items_single_products } from '../ga4-properties'
+import { params, value, currency, client_id, items_single_products, user_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add to Cart',
@@ -11,12 +11,14 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Product Added"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     currency: { ...currency },
     items: {
       ...items_single_products,
       required: true
     },
-    value: { ...value }
+    value: { ...value },
+    params: params
   },
   perform: (request, { payload }) => {
     let googleItems: ProductItem[] = []
@@ -43,13 +45,15 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'add_to_cart',
             params: {
               currency: payload.currency,
               items: googleItems,
-              value: payload.value
+              value: payload.value,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string
@@ -94,4 +98,10 @@ export interface Payload {
      */
     quantity?: number
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/addToWishlist/index.ts
@@ -3,7 +3,7 @@ import { CURRENCY_ISO_CODES } from '../constants'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { value, currency, client_id, items_single_products } from '../ga4-properties'
+import { params, value, currency, client_id, items_single_products, user_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Add to Wishlist',
@@ -11,12 +11,14 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Product Added to Wishlist"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     currency: { ...currency },
     value: { ...value },
     items: {
       ...items_single_products,
       required: true
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     // Make your partner api request here!
@@ -66,13 +68,15 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'add_to_wishlist',
             params: {
               currency: payload.currency,
               value: payload.value,
-              items: googleItems
+              items: googleItems,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Coupon code used for a purchase.
    */
   coupon?: string
@@ -98,4 +102,10 @@ export interface Payload {
    * The monetary value of the event.
    */
   value?: number
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/beginCheckout/index.ts
@@ -1,6 +1,6 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { coupon, currency, client_id, value, items_multi_products } from '../ga4-properties'
+import { params, coupon, currency, client_id, value, items_multi_products, user_id } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -11,6 +11,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Checkout Started"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     coupon: { ...coupon, default: { '@path': '$.properties.coupon' } },
     currency: { ...currency },
     // Google does not have anything to map position, url and image url fields (Segment spec) to
@@ -19,7 +20,8 @@ const action: ActionDefinition<Settings, Payload> = {
       ...items_multi_products,
       required: true
     },
-    value: { ...value }
+    value: { ...value },
+    params: params
   },
   perform: (request, { payload }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.includes(payload.currency)) {
@@ -50,6 +52,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'begin_checkout',
@@ -57,7 +60,8 @@ const action: ActionDefinition<Settings, Payload> = {
               coupon: payload.coupon,
               currency: payload.currency,
               items: googleItems,
-              value: payload.value
+              value: payload.value,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   clientId: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The unique name of the custom event created in GA4. GA4 does not accept spaces in event names so Segment will replace any spaces with underscores. More information about GA4 event name rules is available in [their docs](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article).
    */
   name: string

--- a/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/customEvent/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id } from '../ga4-properties'
+import { params, client_id, user_id } from '../ga4-properties'
 
 const normalizeEventName = (name: string, lowercase: boolean | undefined): string => {
   name = name.trim()
@@ -19,6 +19,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track"',
   fields: {
     clientId: { ...client_id },
+    user_id: { ...user_id },
     name: {
       label: 'Event Name',
       description:
@@ -36,13 +37,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'boolean',
       default: false
     },
-    params: {
-      label: 'Event Parameters',
-      description: 'The event parameters to send to Google',
-      type: 'object',
-      additionalProperties: true,
-      default: { '@path': '$.properties' }
-    }
+    params: { ...params, default: { '@path': '$.properties' } }
   },
   perform: (request, { payload }) => {
     const event_name = normalizeEventName(payload.name, payload.lowercase)
@@ -50,6 +45,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.clientId,
+        user_id: payload.user_id,
         events: [
           {
             name: event_name,

--- a/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/ga4-properties.ts
@@ -1,5 +1,18 @@
 import { InputField } from '@segment/actions-core/src/destination-kit/types'
 
+export const params: InputField = {
+  label: 'Event Parameters',
+  description: 'The event parameters to send to Google',
+  type: 'object',
+  additionalProperties: true
+}
+export const user_id: InputField = {
+  label: 'User ID',
+  type: 'string',
+  description:
+    "A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier."
+}
+
 export const promotion_id: InputField = {
   label: 'Promotion ID',
   type: 'string',

--- a/packages/destination-actions/src/destinations/google-analytics-4/generateLead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/generateLead/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string
@@ -13,4 +17,10 @@ export interface Payload {
    * The monetary value of the event.
    */
   value?: number
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/generateLead/index.ts
@@ -2,7 +2,7 @@ import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id, currency, value } from '../ga4-properties'
+import { params, client_id, user_id, currency, value } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Generate Lead',
@@ -10,8 +10,10 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     currency: { ...currency },
-    value: { ...value }
+    value: { ...value },
+    params: params
   },
   perform: (request, { payload }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.includes(payload.currency)) {
@@ -27,12 +29,14 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'generate_lead',
             params: {
               currency: payload.currency,
-              value: payload.value
+              value: payload.value,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/generated-types.ts
@@ -6,7 +6,17 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The method used to login.
    */
   method?: string
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/login/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id } from '../ga4-properties'
+import { params, user_id, client_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Login',
@@ -9,11 +9,13 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Signed In"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     method: {
       label: 'Method',
       type: 'string',
       description: 'The method used to login.'
-    }
+    },
+    params: params
   },
 
   perform: (request, { payload }) => {
@@ -21,11 +23,13 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'login',
             params: {
-              method: payload.method
+              method: payload.method,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   clientId: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The current page URL
    */
   page_location?: string
@@ -13,4 +17,10 @@ export interface Payload {
    * Previous page URL
    */
   page_referrer?: string
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/pageView/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id } from '../ga4-properties'
+import { params, user_id, client_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Page View',
@@ -9,6 +9,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "page"',
   fields: {
     clientId: { ...client_id },
+    user_id: { ...user_id },
     page_location: {
       label: 'Page Location',
       type: 'string',
@@ -24,19 +25,22 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': '$.context.page.referrer'
       }
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {
         client_id: payload.clientId,
+        user_id: payload.user_id,
         events: [
           {
             name: 'page_view',
             params: {
               page_location: payload.page_location,
-              page_referrer: payload.page_referrer
+              page_referrer: payload.page_referrer,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Store or affiliation from which this transaction occurred (e.g. Google Store).
    */
   affiliation?: string
@@ -114,4 +118,10 @@ export interface Payload {
    * The monetary value of the event.
    */
   value?: number
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/purchase/index.ts
@@ -9,10 +9,12 @@ import {
   transaction_id,
   value,
   client_id,
+  user_id,
   affiliation,
   shipping,
   tax,
-  items_multi_products
+  items_multi_products,
+  params
 } from '../ga4-properties'
 
 // https://segment.com/docs/connections/spec/ecommerce/v2/#order-completed
@@ -23,6 +25,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Order Completed"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     affiliation: { ...affiliation },
     coupon: { ...coupon, default: { '@path': '$.properties.coupon' } },
     currency: { ...currency, required: true },
@@ -35,7 +38,8 @@ const action: ActionDefinition<Settings, Payload> = {
     transaction_id: { ...transaction_id, required: true },
     shipping: { ...shipping },
     tax: { ...tax },
-    value: { ...value, default: { '@path': '$.properties.total' } }
+    value: { ...value, default: { '@path': '$.properties.total' } },
+    params: params
   },
   perform: (request, { payload }) => {
     if (!CURRENCY_ISO_CODES.includes(payload.currency)) {
@@ -66,6 +70,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'purchase',
@@ -77,7 +82,8 @@ const action: ActionDefinition<Settings, Payload> = {
               transaction_id: payload.transaction_id,
               shipping: payload.shipping,
               value: payload.value,
-              tax: payload.tax
+              tax: payload.tax,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string
@@ -114,4 +118,10 @@ export interface Payload {
      */
     quantity?: number
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/refund/index.ts
@@ -4,11 +4,13 @@ import {
   coupon,
   transaction_id,
   client_id,
+  user_id,
   currency,
   value,
   affiliation,
   shipping,
-  items_multi_products
+  items_multi_products,
+  params
 } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -20,6 +22,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Order Refunded"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     currency: { ...currency },
     transaction_id: { ...transaction_id, required: true },
     value: { ...value, default: { '@path': '$.properties.total' } },
@@ -33,7 +36,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     items: {
       ...items_multi_products
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.includes(payload.currency)) {
@@ -82,6 +86,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'refund',
@@ -93,7 +98,8 @@ const action: ActionDefinition<Settings, Payload> = {
               coupon: payload.coupon,
               shipping: payload.shipping,
               tax: payload.tax,
-              items: googleItems
+              items: googleItems,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string
@@ -94,4 +98,10 @@ export interface Payload {
      */
     quantity?: number
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/removeFromCart/index.ts
@@ -1,6 +1,6 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { value, client_id, currency, items_single_products } from '../ga4-properties'
+import { params, value, user_id, client_id, currency, items_single_products } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -11,12 +11,14 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Product Removed"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     currency: { ...currency },
     value: { ...value },
     items: {
       ...items_single_products,
       required: true
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.includes(payload.currency)) {
@@ -65,13 +67,15 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'remove_from_cart',
             params: {
               currency: payload.currency,
               value: payload.value,
-              items: googleItems
+              items: googleItems,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/generated-types.ts
@@ -6,7 +6,17 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The term that was searched for.
    */
   search_term: string
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/search/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id } from '../ga4-properties'
+import { params, user_id, client_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Search',
@@ -9,6 +9,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Products Searched"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     search_term: {
       label: 'Search Term',
       type: 'string',
@@ -17,18 +18,21 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': `$.properties.query`
       }
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'search',
             params: {
-              search_term: payload.search_term
+              search_term: payload.search_term,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The name of the list in which the item was presented to the user.
    */
   item_list_name?: string
@@ -94,4 +98,10 @@ export interface Payload {
      */
     quantity?: number
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectItem/index.ts
@@ -3,7 +3,7 @@ import { CURRENCY_ISO_CODES } from '../constants'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id, items_single_products } from '../ga4-properties'
+import { params, user_id, client_id, items_single_products } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Select Item',
@@ -11,6 +11,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Product Clicked"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     item_list_name: {
       label: 'Item List Name',
       description: 'The name of the list in which the item was presented to the user.',
@@ -24,7 +25,8 @@ const action: ActionDefinition<Settings, Payload> = {
     items: {
       ...items_single_products,
       required: true
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     let googleItems: ProductItem[] = []
@@ -51,13 +53,15 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'select_item',
             params: {
               items: googleItems,
               item_list_name: payload.item_list_name,
-              item_list_id: payload.item_list_id
+              item_list_id: payload.item_list_id,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The name of the promotional creative.
    */
   creative_name?: string
@@ -122,4 +126,10 @@ export interface Payload {
      */
     promotion_id?: string
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/selectPromotion/index.ts
@@ -3,11 +3,13 @@ import { CURRENCY_ISO_CODES } from '../constants'
 import {
   creative_name,
   client_id,
+  user_id,
   creative_slot,
   promotion_id,
   promotion_name,
   minimal_items,
-  items_single_products
+  items_single_products,
+  params
 } from '../ga4-properties'
 import { PromotionProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -19,6 +21,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Promotion Clicked"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     creative_name: { ...creative_name },
     creative_slot: { ...creative_slot, default: { '@path': '$.properties.creative' } },
     location_id: {
@@ -45,7 +48,8 @@ const action: ActionDefinition<Settings, Payload> = {
           ...promotion_id
         }
       }
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     let googleItems: PromotionProductItem[] = []
@@ -80,6 +84,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'select_promotion',
@@ -89,7 +94,8 @@ const action: ActionDefinition<Settings, Payload> = {
               location_id: payload.location_id,
               promotion_id: payload.promotion_id,
               promotion_name: payload.promotion_name,
-              items: googleItems
+              items: googleItems,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/signUp/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/signUp/generated-types.ts
@@ -6,7 +6,17 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The method used for sign up.
    */
   method?: string
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/signUp/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
-import { client_id } from '../ga4-properties'
+import { params, user_id, client_id } from '../ga4-properties'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Sign Up',
@@ -9,6 +9,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Signed Up"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     method: {
       label: 'Method',
       description: 'The method used for sign up.',
@@ -16,18 +17,21 @@ const action: ActionDefinition<Settings, Payload> = {
       default: {
         '@path': `$.properties.type`
       }
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     return request('https://www.google-analytics.com/mp/collect', {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'sign_up',
             params: {
-              method: payload.method
+              method: payload.method,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string
@@ -94,4 +98,10 @@ export interface Payload {
      */
     quantity?: number
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewCart/index.ts
@@ -1,6 +1,6 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { currency, value, client_id, items_multi_products } from '../ga4-properties'
+import { params, currency, value, user_id, client_id, items_multi_products } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -11,12 +11,14 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Cart Viewed"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     currency: { ...currency },
     value: { ...value },
     items: {
       ...items_multi_products,
       required: true
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.includes(payload.currency)) {
@@ -60,13 +62,15 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'view_cart',
             params: {
               currency: payload.currency,
               value: payload.value,
-              items: googleItems
+              items: googleItems,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * Currency of the items associated with the event, in 3-letter ISO 4217 format.
    */
   currency?: string
@@ -94,4 +98,10 @@ export interface Payload {
      */
     quantity?: number
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItem/index.ts
@@ -1,6 +1,6 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { currency, client_id, value, items_single_products } from '../ga4-properties'
+import { params, currency, user_id, client_id, value, items_single_products } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -11,12 +11,14 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event =  "Product Viewed"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     currency: { ...currency },
     value: { ...value },
     items: {
       ...items_single_products,
       required: true
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     if (payload.currency && !CURRENCY_ISO_CODES.includes(payload.currency)) {
@@ -59,13 +61,15 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'view_item',
             params: {
               currency: payload.currency,
               items: googleItems,
-              value: payload.value
+              value: payload.value,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The ID of the list in which the item was presented to the user.
    */
   item_list_id?: string
@@ -94,4 +98,10 @@ export interface Payload {
      */
     quantity?: number
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewItemList/index.ts
@@ -1,6 +1,6 @@
 import { ActionDefinition, IntegrationError } from '@segment/actions-core'
 import { CURRENCY_ISO_CODES } from '../constants'
-import { client_id, items_multi_products } from '../ga4-properties'
+import { params, user_id, client_id, items_multi_products } from '../ga4-properties'
 import { ProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
@@ -15,6 +15,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Product List Viewed"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     item_list_id: {
       label: 'Item List ID',
       type: 'string',
@@ -34,7 +35,8 @@ const action: ActionDefinition<Settings, Payload> = {
     items: {
       ...items_multi_products,
       required: true
-    }
+    },
+    params: params
   },
   perform: (request, { payload }) => {
     let googleItems: ProductItem[] = []
@@ -61,13 +63,15 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'view_item_list',
             params: {
               item_list_id: payload.item_list_id,
               item_list_name: payload.item_list_name,
-              items: googleItems
+              items: googleItems,
+              ...payload.params
             }
           }
         ]

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/generated-types.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/generated-types.ts
@@ -6,6 +6,10 @@ export interface Payload {
    */
   client_id: string
   /**
+   * A unique identifier for a user. See Google's [User-ID for cross-platform analysis](https://support.google.com/analytics/answer/9213390) and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en) documentation for more information on this identifier.
+   */
+  user_id?: string
+  /**
    * The name of the promotional creative.
    */
   creative_name?: string
@@ -122,4 +126,10 @@ export interface Payload {
      */
     promotion_id?: string
   }[]
+  /**
+   * The event parameters to send to Google
+   */
+  params?: {
+    [k: string]: unknown
+  }
 }

--- a/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
+++ b/packages/destination-actions/src/destinations/google-analytics-4/viewPromotion/index.ts
@@ -6,8 +6,10 @@ import {
   promotion_id,
   promotion_name,
   client_id,
+  user_id,
   minimal_items,
-  items_single_products
+  items_single_products,
+  params
 } from '../ga4-properties'
 import { PromotionProductItem } from '../ga4-types'
 import type { Settings } from '../generated-types'
@@ -23,6 +25,7 @@ const action: ActionDefinition<Settings, Payload> = {
   defaultSubscription: 'type = "track" and event = "Promotion Viewed"',
   fields: {
     client_id: { ...client_id },
+    user_id: { ...user_id },
     creative_name: { ...creative_name },
     creative_slot: { ...creative_slot, default: { '@path': '$.properties.creative' } },
     location_id: {
@@ -53,7 +56,8 @@ const action: ActionDefinition<Settings, Payload> = {
           ...promotion_id
         }
       }
-    }
+    },
+    params: params
   },
 
   perform: (request, { payload }) => {
@@ -77,6 +81,7 @@ const action: ActionDefinition<Settings, Payload> = {
       method: 'POST',
       json: {
         client_id: payload.client_id,
+        user_id: payload.user_id,
         events: [
           {
             name: 'view_promotion',
@@ -86,7 +91,8 @@ const action: ActionDefinition<Settings, Payload> = {
               location_id: payload.location_id,
               promotion_id: payload.promotion_id,
               promotion_name: payload.promotion_name,
-              items: googleItems
+              items: googleItems,
+              ...payload.params
             }
           }
         ]


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

* opening this PR against https://github.com/UserLeap/action-destinations for now, will open PR against https://github.com/segmentio/action-destinations once web-sdk changes are approved/deployed
* after new Sprig sdk methods were added allowing setting user ids and attributes/event tracking with the same request, use these methods to reduce request count and improve attribution

## Testing

* existing unit tests passed
* tested against Sprig's staging environment
- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
